### PR TITLE
Add edit user information functionality

### DIFF
--- a/app/src/main/java/is/hbv601g/motorsale/EditUserFragment.java
+++ b/app/src/main/java/is/hbv601g/motorsale/EditUserFragment.java
@@ -1,0 +1,140 @@
+package is.hbv601g.motorsale;
+
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import is.hbv601g.motorsale.DTOs.UserDTO;
+import is.hbv601g.motorsale.services.UserService;
+import is.hbv601g.motorsale.viewModels.UserViewModel;
+
+
+public class EditUserFragment extends Fragment {
+
+    private EditText editTextUsername, editTextEmailAddress, editTextPhone, editTextTextPassword;
+    private Button saveButton;
+    private UserService userService;
+    private UserViewModel userViewModel;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_edit_user, container, false);
+        editTextUsername = view.findViewById(R.id.editTextUsername);
+        editTextEmailAddress = view.findViewById(R.id.editTextEmailAddress);
+        editTextPhone = view.findViewById(R.id.editTextPhone);
+        editTextTextPassword = view.findViewById(R.id.editTextTextPassword);
+        saveButton = view.findViewById(R.id.button);
+        return view;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        userService = new UserService(requireContext());
+        userViewModel = new ViewModelProvider(requireActivity()).get(UserViewModel.class);
+
+        UserDTO currentUser = userViewModel.getUser().getValue();
+        if (currentUser != null) {
+            editTextUsername.setText(currentUser.getUsername());
+            editTextEmailAddress.setText(currentUser.getEmail());
+            editTextPhone.setText(String.valueOf(currentUser.getPhoneNumber()));
+            editTextTextPassword.setText("");
+        } else {
+            Toast.makeText(getContext(), "User info not available", Toast.LENGTH_SHORT).show();
+        }
+
+        saveButton.setOnClickListener(v -> updateUserInfo());
+    }
+
+    private void updateUserInfo() {
+        String newUsername = editTextUsername.getText().toString().trim();
+        String newEmail = editTextEmailAddress.getText().toString().trim();
+        String newPhone = editTextPhone.getText().toString().trim();
+        String newPassword = editTextTextPassword.getText().toString().trim();
+
+        if (userViewModel.getUser().getValue() == null) {
+            Toast.makeText(requireContext(), "User not logged in", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        Long userId = userViewModel.getUser().getValue().getUserId();
+
+        final int[] updatesSent = {0};
+        final int totalUpdates = 4;
+
+        Runnable checkCompletion = () -> {
+            updatesSent[0]++;
+            if (updatesSent[0] == totalUpdates) {
+                String keyForFetch = !TextUtils.isEmpty(newUsername)
+                        ? newUsername
+                        : userViewModel.getUser().getValue().getUsername();
+                userService.fetchUserByEmail(keyForFetch, userDTO -> {
+                    if (userDTO != null) {
+                        userViewModel.setUser(userDTO);
+                    } else {
+                        Toast.makeText(getContext(), "Failed to refresh user info", Toast.LENGTH_SHORT).show();
+                    }
+                    NavController navController = Navigation.findNavController(requireView());
+                    navController.navigate(R.id.action_editUserFragment_to_userFragment);
+                });
+            }
+        };
+
+        if (!TextUtils.isEmpty(newUsername)) {
+            userService.updateUserField(userId, "updateUsername", newUsername, success -> {
+                if (!success) {
+                    Toast.makeText(getContext(), "Failed to update username", Toast.LENGTH_SHORT).show();
+                }
+                checkCompletion.run();
+            });
+        } else {
+            checkCompletion.run();
+        }
+
+        if (!TextUtils.isEmpty(newEmail)) {
+            userService.updateUserField(userId, "updateEmail", newEmail, success -> {
+                if (!success) {
+                    Toast.makeText(getContext(), "Failed to update email", Toast.LENGTH_SHORT).show();
+                }
+                checkCompletion.run();
+            });
+        } else {
+            checkCompletion.run();
+        }
+
+        if (!TextUtils.isEmpty(newPhone)) {
+            userService.updateUserField(userId, "updatePhoneNumber", newPhone, success -> {
+                if (!success) {
+                    Toast.makeText(getContext(), "Failed to update phone number", Toast.LENGTH_SHORT).show();
+                }
+                checkCompletion.run();
+            });
+        } else {
+            checkCompletion.run();
+        }
+
+        if (!TextUtils.isEmpty(newPassword)) {
+            userService.updateUserField(userId, "updatePassword", newPassword, success -> {
+                if (!success) {
+                    Toast.makeText(getContext(), "Failed to update password", Toast.LENGTH_SHORT).show();
+                }
+                checkCompletion.run();
+            });
+        } else {
+            checkCompletion.run();
+        }
+        Toast.makeText(getContext(), "User info updated successfully", Toast.LENGTH_SHORT).show();
+    }
+}

--- a/app/src/main/java/is/hbv601g/motorsale/UserFragment.java
+++ b/app/src/main/java/is/hbv601g/motorsale/UserFragment.java
@@ -20,6 +20,7 @@ import is.hbv601g.motorsale.services.ListingService;
 public class UserFragment extends Fragment {
     private Button createListingButton;
     private Button myListingsButton;
+    private Button editUserButton;
     private ListingService listingsService;
 
     public UserFragment() {
@@ -40,6 +41,12 @@ public class UserFragment extends Fragment {
         myListingsButton.setOnClickListener(v -> {
             NavController navController = Navigation.findNavController(v);
             navController.navigate(R.id.action_userFragment_to_userListingsFragment);
+        });
+
+        editUserButton = view.findViewById(R.id.editUserButton);
+        editUserButton.setOnClickListener(v -> {
+            NavController navController = Navigation.findNavController(v);
+            navController.navigate(R.id.action_userFragment_to_editUserFragment);
         });
 
         return view;

--- a/app/src/main/res/layout/fragment_edit_user.xml
+++ b/app/src/main/res/layout/fragment_edit_user.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".EditUserFragment">
+
+    <EditText
+        android:id="@+id/editTextUsername"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="40dp"
+        android:layout_marginEnd="16dp"
+        android:ems="10"
+        android:hint="New Username"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <EditText
+        android:id="@+id/editTextEmailAddress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="16dp"
+        android:ems="10"
+        android:hint="New Email"
+        android:inputType="textEmailAddress"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editTextPhone" />
+
+    <EditText
+        android:id="@+id/editTextPhone"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="16dp"
+        android:ems="10"
+        android:hint="New Phone Number"
+        android:inputType="phone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editTextUsername" />
+
+    <EditText
+        android:id="@+id/editTextTextPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginEnd="16dp"
+        android:ems="10"
+        android:hint="New Password"
+        android:inputType="textPassword"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editTextEmailAddress" />
+
+    <Button
+        android:id="@+id/button"
+        android:layout_width="wrap_content"
+        android:layout_height="48dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="32dp"
+        android:layout_marginEnd="32dp"
+        android:text="Save Changes"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editTextTextPassword" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_user.xml
+++ b/app/src/main/res/layout/fragment_user.xml
@@ -20,7 +20,7 @@
             android:text="Create Listing" />
 
         <Button
-            android:id="@+id/button2"
+            android:id="@+id/editUserButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Edit Personal Info" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -65,6 +65,9 @@
         <action
             android:id="@+id/action_userFragment_to_userListingsFragment"
             app:destination="@id/userListingsFragment" />
+        <action
+            android:id="@+id/action_userFragment_to_editUserFragment"
+            app:destination="@id/editUserFragment" />
     </fragment>
 
     <!-- Create Listing Fragment -->
@@ -90,6 +93,24 @@
         <!-- Argument for passing listingId to the EditListingFragment -->
         <argument
             android:name="listingId"
+            app:argType="string"
+            android:defaultValue="" />
+    </fragment>
+
+    <!-- Edit User Fragment (Added for editing user information) -->
+    <fragment
+        android:id="@+id/editUserFragment"
+        android:name="is.hbv601g.motorsale.EditUserFragment"
+        android:label="Edit User"
+        tools:layout="@layout/fragment_edit_user">
+
+        <action
+            android:id="@+id/action_editUserFragment_to_userFragment"
+            app:destination="@id/userFragment" />
+
+        <!-- Argument for passing userId to the EditUserFragment -->
+        <argument
+            android:name="userId"
             app:argType="string"
             android:defaultValue="" />
     </fragment>


### PR DESCRIPTION
Adds a edit user information page on the user fragment. There the user can edit their username, phone number, email and/or password. The old/current values are displayed in the fields on the Edit User page, if a field is changed or anything written in the password field, the corresponding information will be updated (patch request sent) and the user is sent to the user page.